### PR TITLE
[fix]my.cnf内にあるログ出力関連設定ファイルの保管先を修正

### DIFF
--- a/docker/db/my.cnf
+++ b/docker/db/my.cnf
@@ -18,17 +18,17 @@ default-time-zone = SYSTEM
 log_timestamps = SYSTEM
 
 # Error Log
-log-error = /var/lib/mysql/mysql-error.log
+log-error = /var/log/mysql/mysql-error.log
 
 # Slow Query Log
 slow_query_log = 1
-slow_query_log_file = /var/lib/mysql/mysql-slow.log
+slow_query_log_file = /var/log/mysql/mysql-slow.log
 long_query_time = 1.0
 log_queries_not_using_indexes = 0
 
 # General Log
 general_log = 1
-general_log_file = /var/lib/mysql/mysql-general.log
+general_log_file = /var/log/mysql/mysql-general.log
 
 [mysql]
 default-character-set = utf8mb4


### PR DESCRIPTION
ログ出力関連設定ファイル保管先をdocker volumeにしていたため、コンテナ内への保管に変更