### PR TITLE
[fix]中間テーブルへデータを保存できない不具合を修正

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -2,7 +2,10 @@
     "name": "laravel/laravel",
     "type": "project",
     "description": "The Laravel Framework.",
-    "keywords": ["framework", "laravel"],
+    "keywords": [
+        "framework",
+        "laravel"
+    ],
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0",
@@ -29,7 +32,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "classmap": [
+            "app/traits"
+        ]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
HasCompositePrimaryKeyTrait.phpを読み込めない不具合のため、読み込み可能なようにcomposer.jsonのautoloadの部分に、Traitを置いているディレクトリを追記した。