### PR TITLE
[fix]メモを公開したグループ名が1つしか表示されない不具合を修正

### DIFF
--- a/src/app/Http/ViewComposers/MemoGroupComposer.php
+++ b/src/app/Http/ViewComposers/MemoGroupComposer.php
@@ -22,7 +22,8 @@ class MemoGroupComposer
     public function compose(View $view)
     {
         $view->with([
-            'memo_groups' =>User::find(Auth::id())->memogroup()->paginate(2, ['*'], 'groupPage')->appends(['bookReadingPage' => \Request::get('bookReadingPage'), 'bookInterestingPage' => \Request::get('bookInterestingPage')])
+            'memo_groups_paginate' => User::find(Auth::id())->memogroup()->paginate(2, ['*'], 'groupPage')->appends(['bookReadingPage' => \Request::get('bookReadingPage'), 'bookInterestingPage' => \Request::get('bookInterestingPage')]),
+            'memo_groups' => User::find(Auth::id())->memogroup()->get()
         ]);
     }
 }

--- a/src/public/css/app.css
+++ b/src/public/css/app.css
@@ -1115,9 +1115,9 @@ select {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
 }
-.bg-primary {
+.bg-menu {
   --tw-bg-opacity: 1;
-  background-color: rgb(59 57 77 / var(--tw-bg-opacity));
+  background-color: rgb(26 37 70 / var(--tw-bg-opacity));
 }
 .bg-slate-50 {
   --tw-bg-opacity: 1;
@@ -1130,6 +1130,10 @@ select {
   --tw-bg-opacity: 1;
   background-color: rgb(255 249 249 / var(--tw-bg-opacity));
 }
+.bg-primary {
+  --tw-bg-opacity: 1;
+  background-color: rgb(59 57 77 / var(--tw-bg-opacity));
+}
 .bg-slate-200 {
   --tw-bg-opacity: 1;
   background-color: rgb(226 232 240 / var(--tw-bg-opacity));
@@ -1137,10 +1141,6 @@ select {
 .bg-slate-300 {
   --tw-bg-opacity: 1;
   background-color: rgb(203 213 225 / var(--tw-bg-opacity));
-}
-.bg-menu {
-  --tw-bg-opacity: 1;
-  background-color: rgb(26 37 70 / var(--tw-bg-opacity));
 }
 .bg-gray-100 {
   --tw-bg-opacity: 1;
@@ -1910,9 +1910,18 @@ select {
     padding-left: 3rem;
   }
 
+  .md\:pl-20 {
+    padding-left: 5rem;
+  }
+
   .md\:text-2xl {
     font-size: 1.5rem;
     line-height: 2rem;
+  }
+
+  .md\:text-black {
+    --tw-text-opacity: 1;
+    color: rgb(0 0 0 / var(--tw-text-opacity));
   }
 
   .md\:text-normal {
@@ -1923,11 +1932,6 @@ select {
   .md\:text-subtitle {
     --tw-text-opacity: 1;
     color: rgb(239 239 239 / var(--tw-text-opacity));
-  }
-
-  .md\:text-black {
-    --tw-text-opacity: 1;
-    color: rgb(0 0 0 / var(--tw-text-opacity));
   }
 }
 @media (min-width: 1024px) {

--- a/src/resources/views/book/create.blade.php
+++ b/src/resources/views/book/create.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-xl"><a href="{{ route('book.index') }}" class="flex items-center justify-center text-normal"><iconify-icon icon="ci:external-link"></iconify-icon>本の登録</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/book/index.blade.php
+++ b/src/resources/views/book/index.blade.php
@@ -18,7 +18,7 @@
 
             <x-top-menu />
 
-            <x-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 
@@ -26,7 +26,7 @@
             @if(isset($selectedBook))
                 @if($selectedBook->state == '読書中')
                     <h2 class="px-10 pt-10 font-medium text-xl">読書中</h2>
-                    <div class="bg-primary p-8 ml-20 mt-8 rounded-xl h-1/2">
+                    <div class="bg-primary p-8 ml-20 mt-8 rounded-xl">
 
                         @if($memo_groups->isEmpty())
                             <div class="flex justify-end">
@@ -59,13 +59,11 @@
                                 <p class="pt-6">{{$genre_name}}</p>
 
                                 @if(!($selectedBook->memo->isEmpty()))
-                                    <div class="text-xl bg-slate-50 py-2 px-4 rounded-xl mt-4 text-black">
+                                    <div class="hidden md:block text-xl md:bg-slate-50 py-2 px-4 rounded-xl mt-4 text-black">
                                         <p class="pt-2">公開中のグループ：</p>
                                         @foreach($selectedBook->memo as $memo)
                                             @if($memo_groups->find($memo->group_id))
                                                 <p class="pt-2 pl-6">{{ $memo_groups->find($memo->group_id)->group_name}}</p>
-                                            @else
-                                                <p class="pt-2 pl-6">※グループなし</p>
                                             @endif
                                         @endforeach
                                     </div>
@@ -97,19 +95,6 @@
                                 <p id="title">{{$selectedBook->title}}</p>
                                 <p class="pt-6">{{$selectedBook->author}}</p>
                                 <p class="pt-6">{{$genre_name}}</p>
-
-                                @if(!($selectedBook->memo->isEmpty()))
-                                    <div class="text-xl bg-slate-50 py-2 px-4 rounded-xl mt-4">
-                                        <p class="pt-2">公開中のグループ：</p>
-                                        @foreach($selectedBook->memo as $memo)
-                                            @if($memo_groups->find($memo->group_id))
-                                                <p class="pt-2 pl-6">{{ $memo_groups->find($memo->group_id)->group_name}}</p>
-                                            @else
-                                                <p class="pt-2 pl-6">※グループなし</p>
-                                            @endif
-                                        @endforeach
-                                    </div>
-                                @endif
                             </div>
                         </div>
                     </div>

--- a/src/resources/views/book/manual.blade.php
+++ b/src/resources/views/book/manual.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-xl text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>本の登録</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/book/search.blade.php
+++ b/src/resources/views/book/search.blade.php
@@ -21,7 +21,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-xl text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>本の追加</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/book/show.blade.php
+++ b/src/resources/views/book/show.blade.php
@@ -19,7 +19,7 @@
 
             <x-top-menu />
 
-            <x-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 
@@ -65,7 +65,7 @@
                     </div>
 
                     <h2 class="hidden md:block px-10 pt-10 font-medium text-xl">読書中</h2>
-                    <div class="md:bg-primary p-4 md:p-8 md:ml-20 mt-8 rounded-xl md:h-1/2">
+                    <div class="md:bg-primary p-4 md:p-8 md:ml-20 mt-8 rounded-xl">
                         @if($memo_groups->isEmpty())
                             <div class="flex justify-end">
                                 <form action="{{route('book.destroy', $selectedBook)}}" method="post">
@@ -102,8 +102,6 @@
                                         @foreach($selectedBook->memo as $memo)
                                             @if($memo_groups->find($memo->group_id))
                                                 <p class="pt-2 pl-6">{{ $memo_groups->find($memo->group_id)->group_name}}</p>
-                                            @else
-                                                <p class="pt-2 pl-6">※グループなし</p>
                                             @endif
                                         @endforeach
                                     </div>
@@ -117,8 +115,6 @@
                                 @foreach($selectedBook->memo as $memo)
                                     @if($memo_groups->find($memo->group_id))
                                         <p class="pt-2 pl-6">{{ $memo_groups->find($memo->group_id)->group_name}}</p>
-                                    @else
-                                        <p class="pt-2 pl-6">※グループなし</p>
                                     @endif
                                 @endforeach
                             </div>
@@ -163,8 +159,9 @@
                             </div>
                         </div>
                     </div>
+
                     <h2 class="hidden md:block px-10 pt-10 font-medium text-xl">気になる</h2>
-                    <div class="md:bg-primary p-4 md:p-8 md:ml-20 mt-8 rounded-xl md:h-1/2">
+                    <div class="md:bg-primary p-4 md:p-8 md:ml-20 mt-8 rounded-xl">
                         <div class="flex justify-between">
                             <div class="hover:after:content-['「気になる」から「読書中」に移動する'] hover:after:relative hover:after:-top-10 hover:after:-left-10 hover:after:bg-gray-700 hover:after:text-stone-50 hover:after:rounded hover:after:p-2 hover:after:text-">
                                 <a href="{{ route('book.update', $selectedBook->id) }}" class="inline-block bg-slate-200 hover:bg-sky-500 hover:text-slate-50 border p-1 rounded-xl px-4"><iconify-icon inline icon="cil:data-transfer-up" width="24" height="24"></iconify-icon></a>

--- a/src/resources/views/group-user-memo/index.blade.php
+++ b/src/resources/views/group-user-memo/index.blade.php
@@ -20,7 +20,7 @@
 
             <x-top-menu />
 
-            <x-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/group-user-memo/publish-status.blade.php
+++ b/src/resources/views/group-user-memo/publish-status.blade.php
@@ -20,7 +20,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-sm text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>メモの公開・非公開</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/group-user-memo/show.blade.php
+++ b/src/resources/views/group-user-memo/show.blade.php
@@ -29,7 +29,7 @@
                 </div>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/group-user/add.blade.php
+++ b/src/resources/views/group-user/add.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-sm text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>メンバーの追加</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/group-user/edit.blade.php
+++ b/src/resources/views/group-user/edit.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-sm text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>メンバーの削除</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/group-user/search.blade.php
+++ b/src/resources/views/group-user/search.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-lg text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>グループの作成</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/group/create.blade.php
+++ b/src/resources/views/group/create.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-lg"><a href="{{ route('book.index') }}" class="flex items-center justify-center text-normal"><iconify-icon icon="ci:external-link"></iconify-icon>グループの作成</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/memo/edit.blade.php
+++ b/src/resources/views/memo/edit.blade.php
@@ -28,7 +28,7 @@
                 </div>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/memo/show.blade.php
+++ b/src/resources/views/memo/show.blade.php
@@ -43,7 +43,7 @@
             @if(strpos(url()->full(),'search_title') !== false)
                 <x-sp-hidden-search-memo-list />
             @else
-                <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+                <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
             @endif
 
         </section>

--- a/src/resources/views/search-book/index.blade.php
+++ b/src/resources/views/search-book/index.blade.php
@@ -40,7 +40,7 @@
 
                             {{ $search_books->links('vendor.pagination.custom') }}
                         @else
-                            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+                            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
                         @endif
                         </ul>
                     </li>

--- a/src/resources/views/setting/book-sort-edit.blade.php
+++ b/src/resources/views/setting/book-sort-edit.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-sm text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>本の並び替え</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/setting/email-edit.blade.php
+++ b/src/resources/views/setting/email-edit.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-sm text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>メールアドレスの変更</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/setting/genre-name-edit.blade.php
+++ b/src/resources/views/setting/genre-name-edit.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-sm text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>ジャンル名の追加</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/setting/password-edit.blade.php
+++ b/src/resources/views/setting/password-edit.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-sm text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>パスワードの変更</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 

--- a/src/resources/views/setting/user-name-edit.blade.php
+++ b/src/resources/views/setting/user-name-edit.blade.php
@@ -19,7 +19,7 @@
                 <h2 class="md:px-10 md:pt-10 font-medium text-sm text-normal"><a href="{{ route('book.index') }}" class="flex items-center justify-center"><iconify-icon icon="ci:external-link"></iconify-icon>ユーザー名称の変更</a></h2>
             </x-top-menu>
 
-            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups" />
+            <x-sp-hidden-memo-list :books-reading="$books_reading" :books-interesting="$books_interesting" :memo-groups="$memo_groups_paginate" />
 
         </section>
 


### PR DESCRIPTION
paginateで表示された部分のグループ名のみが表示される設定になっていたため、
公開した全てのグループ名が表示されるよう$memo_groupsを修正した